### PR TITLE
Fixing items equipment and battle items 

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -495,11 +495,12 @@ position = Vector2(391, 110)
 
 [node name="Inventory_Item" parent="." instance=ExtResource("9_6t2tt")]
 position = Vector2(228, 128)
-item_type = "1"
-item_name = "fish"
+item_type = "Equipment"
+item_name = "SteelSword"
 item_texture = ExtResource("10_3yj14")
-item_effect = "sword"
+item_effect = "Damage+5"
 item_price = 100
+equip_effect = 5
 
 [node name="Inventory_Item2" parent="." instance=ExtResource("9_6t2tt")]
 position = Vector2(266, 151)

--- a/Scripts/InventoryItem.cs
+++ b/Scripts/InventoryItem.cs
@@ -25,6 +25,8 @@ public partial class InventoryItem : Node2D
 	public string item_effect{ get; set; } = "";
 	[Export]
 	public int item_price{get; set;} = 0;
+	[Export]
+	public int equip_effect{get; set;} = 0;
 
 	//Global Reference
 	public Global glbl;
@@ -79,7 +81,8 @@ public partial class InventoryItem : Node2D
 			{ "item_name", item_name },
 			{ "item_texture", item_texture },
 			{ "item_effect", item_effect },
-			{ "item_price", item_price }
+			{ "item_price", item_price },
+			{ "equip_effect", equip_effect }
 		};
 		
 		if(glbl.player_node != null){

--- a/Scripts/InventorySlot.cs
+++ b/Scripts/InventorySlot.cs
@@ -51,10 +51,9 @@ public partial class InventorySlot : Control
 
 	private void OnItemButtonPressed()
 	{
-		if (item != null)
+		if (item != null && usage_panel.Visible == false)
 		{
-			usage_panel.Visible = !usage_panel.Visible;
-			details_panel.Visible = !details_panel.Visible;
+			usage_panel.Visible = true;
 		}
 	}
 	/*
@@ -152,13 +151,16 @@ public partial class InventorySlot : Control
 			glbl.RemoveItem(item["item_type"], item["item_effect"]);
 			glbl.custom_signals.EmitSignal(nameof(CustomSignals.OnItemUsed),item["item_effect"]);
 		}
-		if(item["item_effect"] == "sword" && glbl.isBattling == false) 
+		if(item["item_type"] == "Equipment")
 		{
-			glbl.weapon = item["item_effect"];
-			glbl.damage = glbl.basedamage + 5;
-			glbl.RemoveItem(item["item_type"], item["item_effect"]);
+			if(item["item_name"] == "SteelSword" && glbl.isBattling == false) 
+			{
+				glbl.weapon = item["item_name"];
+				glbl.damage = glbl.basedamage + item["equip_effect"];
+				glbl.RemoveItem(item["item_type"], item["item_effect"]);
+			}
 		}
-		
+			
 		// Dont know what to do with a map.
 		
 

--- a/Scripts/InventorySlot.cs
+++ b/Scripts/InventorySlot.cs
@@ -51,9 +51,14 @@ public partial class InventorySlot : Control
 
 	private void OnItemButtonPressed()
 	{
-		if (item != null && usage_panel.Visible == false)
+		if (item != null && usage_panel.Visible == false && details_panel.Visible == true)
 		{
 			usage_panel.Visible = true;
+			details_panel.Visible = !details_panel.Visible;
+		}
+		else if (item!= null && details_panel.Visible == false && usage_panel.Visible == false)
+		{
+			details_panel.Visible = !details_panel.Visible;
 		}
 	}
 	/*


### PR DESCRIPTION
Made a mistake and committed to dev instead of branching off before committing to branch and doing pull request. I rectified this by branching off and fixing the item usage panel. It was ugly and overlapping. 

Gave Equipments Effects and allowed for Global to be updated with equipment name, damage, and a base damage value so that equipment can be compared.

Changed CustomSignals to pass ItemEffects, but this will probably be changed again so that we can differentiate types of potions if we get that far.

Implemented global values in battle directly so that you can use Traps

Speaking of, battle items (traps and firebombs) are implemented now. Traps are damage reflection.

Items now pass off to the Enemy turn and set healths in case damage was inflicted or healed.

Various minor changes and corrections in logic were made to keep things precise.