### PR TITLE
Hotfix to fix key edge case and battle inventory ui

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -518,6 +518,14 @@ item_texture = ExtResource("12_52737")
 item_effect = "key"
 item_price = 100
 
+[node name="Inventory_Item8" parent="." instance=ExtResource("9_6t2tt")]
+position = Vector2(201, 151)
+item_type = "3"
+item_name = "jeffery"
+item_texture = ExtResource("12_52737")
+item_effect = "key"
+item_price = 100
+
 [node name="Inventory_Item4" parent="." instance=ExtResource("9_6t2tt")]
 position = Vector2(298, 161)
 item_type = "4"

--- a/Scripts/Battle.cs
+++ b/Scripts/Battle.cs
@@ -67,7 +67,7 @@ public partial class Battle : Control
 	public async void OnItemUsed(string ItemEffect){
 		GD.Print("Item Used.");
 		GD.Print($"{ItemEffect}");
-		GetNode<CanvasLayer>("InventoryUI").Visible = false;
+		player.inventory_ui.Visible = !player.inventory_ui.Visible;
 		
 		if (ItemEffect == "firebomb")
 		{
@@ -97,8 +97,12 @@ public partial class Battle : Control
 			//GetTree().Paused = false;
 			GD.Print("Text Closed");
 			GetNode<Control>("Textbox").Hide();
-			EmitSignal(nameof(TextClosed));
+			EmitSignal(nameof(TextClosed));		
+		}
 		
+		if(@event.IsActionPressed("ui_inventory"))
+		{
+			GetNode<CanvasLayer>("InventoryUI").Visible = false;
 		}
 	}
 	public void display_text(String text)
@@ -178,7 +182,9 @@ public partial class Battle : Control
 	}
 	public void On_items_pressed()
 	{
-		GetNode<CanvasLayer>("InventoryUI").Visible = true;
+		player.inventory_ui.Visible = !player.inventory_ui.Visible;
+		player.inventory_money.Text = "Money = " + glbl.money.ToString();
+		player.inventory_health.Text = "Health = " + glbl.health.ToString();
 		//GetTree().Paused = !GetTree().Paused;
 		//JUST FOR DEMO
 		
@@ -190,4 +196,5 @@ public partial class Battle : Control
 	public override void _Process(double delta)
 	{
 	}
+	
 }

--- a/Scripts/InventorySlot.cs
+++ b/Scripts/InventorySlot.cs
@@ -171,11 +171,16 @@ public partial class InventorySlot : Control
 			glbl.RemoveItem(item["item_type"], item["item_effect"]);
 			glbl.custom_signals.EmitSignal(nameof(CustomSignals.OnItemUsed),item_effect);
 		}
-		if(item["item_effect"] == "key" && glbl.isBattling == false)
+		if(item["item_effect"] == "key" && glbl.isBattling == false && glbl.door == false)
 		{
 			glbl.door = true;
 			glbl.RemoveItem(item["item_type"], item["item_effect"]);
 			glbl.custom_signals.EmitSignal(nameof(CustomSignals.OnItemUsed),item["item_effect"]);
+		}
+		if(item["item_effect"] == "key" && glbl.isBattling == true || glbl.door == true)
+		{
+			glbl.door = true;
+			GD.Print("You can't use that now.");
 		}
 			
 		// Dont know what to do with a map.


### PR DESCRIPTION
When another key would be added to the scene, the previous logic would allow for consumption of excess keys without any benefit.

This way, it will check to see if a key has already been used, and it will not allow a key to be used in that case

ALSO FIXED BATTLE INVENTORY TO ALLOW FOR THE INVENTORY TO BE CLOSED WITHOUT USING AN ITEM